### PR TITLE
feat(pre-course): capture pre-course counselling for all HFSE-IS appl…

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -8,7 +8,12 @@
       "Bash(python skills/ui-ux-pro-max/scripts/search.py \"school enrollment feedback survey form celebratory warm\" --design-system -p \"Parent Feedback Survey\" -f markdown)",
       "Bash(python src/ui-ux-pro-max/scripts/search.py \"school enrollment feedback survey form celebratory warm\" --design-system -p \"Parent Feedback Survey\" -f markdown)",
       "Bash(xargs grep -l \"icaPhoto\\\\|vaccinationInformation\\\\|financialSupportDocs\")",
-      "Bash(git add *)"
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git pull *)",
+      "Bash(git stash *)",
+      "Bash(git push *)",
+      "Bash(Get-Content *)"
     ]
   },
   "enabledPlugins": {

--- a/src/components/layout/new-student-layout.tsx
+++ b/src/components/layout/new-student-layout.tsx
@@ -181,6 +181,7 @@ function SubmitApplicationDialog() {
   const { formState } = useEnrolNewStudentContext();
   const preCourseAnswer = usePreCourseAcknowledgementStore((state) => state.preCourseAnswer) as string;
   const preCourseDate = usePreCourseAcknowledgementStore((state) => state.preCourseDate) as Date;
+  const clearPreCourse = usePreCourseAcknowledgementStore((state) => state.clearState);
   const { mutate, isPending } = useMutation({
     mutationFn: async (enrollmentDetails: EnrolNewStudentFormState) => {
       return await submitEnrollment(enrollmentDetails, academicYear, {
@@ -206,6 +207,7 @@ function SubmitApplicationDialog() {
         queryKey: ["student-enrollments-list", session?.user.email],
       });
       clearEnrolNewStudentTabState();
+      clearPreCourse();
       sessionStorage.clear();
     },
     onError() {

--- a/src/components/private/enrol-student/submit-application-dialog.tsx
+++ b/src/components/private/enrol-student/submit-application-dialog.tsx
@@ -32,6 +32,7 @@ function SubmitApplicationDialog() {
   const { formState, clearState } = useEnrolOldStudentContext();
   const preCourseAnswer = usePreCourseAcknowledgementStore((state) => state.preCourseAnswer) as string;
   const preCourseDate = usePreCourseAcknowledgementStore((state) => state.preCourseDate) as Date;
+  const clearPreCourse = usePreCourseAcknowledgementStore((state) => state.clearState);
   const stpApplicationType = usePassTypeStore((state) => state.stpApplicationType);
   const { mutate, isPending } = useMutation({
     mutationFn: async () => {
@@ -59,6 +60,7 @@ function SubmitApplicationDialog() {
         queryKey: ["student-enrollments-list", session?.user.email],
       });
       clearState();
+      clearPreCourse();
       sessionStorage.clear();
     },
     onError(error) {

--- a/src/pages/private/enrol-student/residency-status.tsx
+++ b/src/pages/private/enrol-student/residency-status.tsx
@@ -165,7 +165,6 @@ export default function StudentResidencyPage() {
 
   const [selected, setSelected] = useState<(typeof residencyOptions)[number] | null>(null);
 
-  const academicYear = useSelectAcademicYear((state) => state.academicYear);
   const passType = usePassTypeStore((state) => state.passType);
   const stpApplicationType = usePassTypeStore((state) => state.stpApplicationType);
   const setStpApplicationType = usePassTypeStore((state) => state.setStpApplicationType);
@@ -212,22 +211,11 @@ export default function StudentResidencyPage() {
       return;
     }
 
-    if (applicationTypes.includes(stpApplicationType)) {
-      navigate("/enrol-student/stp-guidelines", {
-        state: { enroleeNumber, enroleeType },
-      });
-      return;
-    }
-
-    const url =
-      enroleeType === "Current"
-        ? `/enrol-student/${enroleeNumber}/student-info?academicYear=${academicYear}`
-        : `/enrol-student/new/student-info?academicYear=${academicYear}`;
-
-    navigate(url, {
+    navigate("/enrol-student/stp-guidelines", {
       state: {
-        enroleeType,
         enroleeNumber,
+        enroleeType,
+        isSTP: applicationTypes.includes(stpApplicationType),
       },
     });
   }

--- a/src/pages/private/enrol-student/stp-guidelines.tsx
+++ b/src/pages/private/enrol-student/stp-guidelines.tsx
@@ -33,7 +33,7 @@ function STPGuidelines() {
   const { academicYear } = useSelectAcademicYear();
   const navigate = useNavigate();
   const { state } = useLocation();
-  const { enroleeType, isOpenHouseRegistration } = state;
+  const { enroleeType, isOpenHouseRegistration, isSTP = true } = state;
 
   useEffect(() => {
     if (!isOpenHouseRegistration) return;
@@ -41,8 +41,9 @@ function STPGuidelines() {
     setPreCourseDate(new Date());
   }, [isOpenHouseRegistration]);
 
-  const canContinue =
-    icaAcknowledged && feesAcknowledged && preCourseAnswer && (preCourseAnswer === "No" || !!preCourseDate);
+  const canContinue = isSTP
+    ? icaAcknowledged && feesAcknowledged && preCourseAnswer && (preCourseAnswer === "No" || !!preCourseDate)
+    : preCourseAnswer && (preCourseAnswer === "No" || !!preCourseDate);
 
   const phone = "+65 8200 0062";
 
@@ -95,38 +96,54 @@ function STPGuidelines() {
             </div>
 
             <h1 className="text-3xl md:text-4xl lg:text-6xl font-black tracking-tight">
-              <span className="text-primary">Student Pass Acknowledgement</span>
+              <span className="text-primary">
+                {isSTP ? "Student Pass Acknowledgement" : "Pre-Course Counselling Acknowledgement"}
+              </span>
             </h1>
 
             <p className="text-lg md:text-xl text-slate-600 max-w-2xl mx-auto leading-relaxed px-4">
-              We're here to guide your family through Singapore's Student Pass process.
-              <span className="font-semibold text-slate-700">
-                {" "}
-                Just review and check the boxes below—simple as that!
-              </span>
+              {isSTP ? (
+                <>
+                  We're here to guide your family through Singapore's Student Pass process.
+                  <span className="font-semibold text-slate-700">
+                    {" "}
+                    Just review and check the boxes below—simple as that!
+                  </span>
+                </>
+              ) : (
+                <>
+                  Before enrolment, please confirm your Pre-Course Counselling status.
+                  <span className="font-semibold text-slate-700">
+                    {" "}
+                    Just answer the question below to continue.
+                  </span>
+                </>
+              )}
             </p>
           </div>
         </div>
         {/* SECTION HEADER */}
-        <div className="mt-24 text-center space-y-4">
-          <Separator />
-          <br />
-          <br />
-          <div className="w-max mx-auto px-6 py-2 rounded-full text-[10px] font-black uppercase tracking-[0.2em] bg-gradient-to-r from-amber-50 to-amber-100 text-amber-700 border border-amber-300 shadow-md shadow-amber-100/50">
-            Action Required
+        {isSTP && (
+          <div className="mt-24 text-center space-y-4">
+            <Separator />
+            <br />
+            <br />
+            <div className="w-max mx-auto px-6 py-2 rounded-full text-[10px] font-black uppercase tracking-[0.2em] bg-gradient-to-r from-amber-50 to-amber-100 text-amber-700 border border-amber-300 shadow-md shadow-amber-100/50">
+              Action Required
+            </div>
+            <h2 className="text-3xl md:text-4xl font-black tracking-tighter text-amber-700">
+              Please Review and Acknowledge the Information
+            </h2>
+            <p className="text-slate-600 mx-auto max-w-lg text-base leading-relaxed">
+              Kindly read each section carefully and tick the checkbox to confirm your understanding before continuing
+              with the application.
+            </p>
           </div>
-          <h2 className="text-3xl md:text-4xl font-black tracking-tighter text-amber-700">
-            Please Review and Acknowledge the Information
-          </h2>
-          <p className="text-slate-600 mx-auto max-w-lg text-base leading-relaxed">
-            Kindly read each section carefully and tick the checkbox to confirm your understanding before continuing
-            with the application.
-          </p>
-        </div>
+        )}
 
         {/* Acknowledgement Cards */}
         <section className="mx-auto py-12">
-          <div className="grid lg:grid-cols-2 gap-8">
+          {isSTP && <div className="grid lg:grid-cols-2 gap-8">
             {/* Student's Pass Card */}
             <div className="group p-8 rounded-xl border border-slate-200 bg-white shadow-md hover:shadow-xl transition-all duration-300 space-y-6 hover:border-amber-700/30">
               <div className="flex flex-wrap items-center gap-3">
@@ -242,7 +259,7 @@ function STPGuidelines() {
                 </label>
               </div>
             </div>
-          </div>
+          </div>}
 
           {/* 2. Pre-Course Counselling Section */}
           <div className="mt-8 rounded-2xl bg-white border border-amber-200 p-8 space-y-6 shadow-sm">


### PR DESCRIPTION
…icants

Route all non-open-house applicants through stp-guidelines regardless of pass type, passing isSTP flag to conditionally show STP acknowledgement cards (ICA/fees) for STP applicants only and pre-course section for everyone. Fixes blank preCourseAnswer in DB for non-STP applicants. Also add clearPreCourse() on successful submission in both new-student and re-enrollment flows.