### PR TITLE
refactor(academic-year): centralize AY lists into a single config source

### DIFF
--- a/src/actions/private.ts
+++ b/src/actions/private.ts
@@ -1,3 +1,4 @@
+import { BACKEND_ACADEMIC_YEARS } from "@/config/academic-years";
 import { applicationTypes } from "@/data";
 import { supabase } from "@/lib/client";
 import {
@@ -530,7 +531,7 @@ export async function getFamilyInformation(enroleeNumber?: string) {
           if (!match) throw new Error("Invalid enrolee number format");
           return [`ay20${match[1]}`];
         })()
-      : ["ay2027", "ay2026", "ay2025"];
+      : BACKEND_ACADEMIC_YEARS;
 
     for (const academicYear of academicYears) {
       let query = supabase
@@ -675,7 +676,7 @@ export async function getPreviousParentGuardianDocuments(enroleeNumber?: string)
           if (!match) throw new Error("Invalid enrolee number format");
           return [`ay20${match[1]}`];
         })()
-      : ["ay2027", "ay2026", "ay2025"];
+      : BACKEND_ACADEMIC_YEARS;
 
     for (const academicYear of academicYears) {
       let appQuery = supabase

--- a/src/components/layout/new-student-layout.tsx
+++ b/src/components/layout/new-student-layout.tsx
@@ -6,6 +6,7 @@ import NewStudentSteps from "../private/enrol-student/new-student-steps";
 import { buttonVariants } from "../ui/button";
 
 import { submitEnrollment } from "@/actions/private";
+import { BACKEND_ACADEMIC_YEARS } from "@/config/academic-years";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -48,7 +49,7 @@ import { useMediaQuery } from "react-responsive";
 import { toast } from "sonner";
 import ISSavedDraftsDialog from "../private/is-saved-drafts-list";
 
-const academicYears = ["ay2025", "ay2026", "ay2027"];
+const academicYears = BACKEND_ACADEMIC_YEARS;
 
 function NewStudentLayout() {
   const studentDrafts = listNewStudentDrafts("hfse-is") || [];

--- a/src/components/layout/old-student-layout.tsx
+++ b/src/components/layout/old-student-layout.tsx
@@ -1,3 +1,4 @@
+import { BACKEND_ACADEMIC_YEARS } from "@/config/academic-years";
 import EnrolOldStudentContextProvider, { useEnrolOldStudentContext } from "@/context/enrol-old-student-context";
 import { ArrowLeft } from "lucide-react";
 import { Outlet, useNavigate, useSearchParams } from "react-router";
@@ -33,7 +34,7 @@ import { OctagonAlert } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useMediaQuery } from "react-responsive";
 
-const academicYears = ["ay2025", "ay2026", "ay2027"];
+const academicYears = BACKEND_ACADEMIC_YEARS;
 
 function OldStudentLayout() {
   const academicYear = useSelectAcademicYear((state) => state.academicYear);

--- a/src/components/layout/vizschool/current-learner-layout.tsx
+++ b/src/components/layout/vizschool/current-learner-layout.tsx
@@ -1,3 +1,4 @@
+import { VIZSCHOOL_ACADEMIC_YEARS } from "@/config/academic-years";
 import MaxWidthWrapper from "@/components/max-width-wrapper";
 import CurrentLearnerSteps from "@/components/private/enrol-student/vizschool/current-learner-steps";
 import SubmitLearnerApplicationDialog from "@/components/private/enrol-student/vizschool/submit-learner-application-dialog";
@@ -32,7 +33,7 @@ import { useEffect, useState } from "react";
 import { useMediaQuery } from "react-responsive";
 import { Outlet, useNavigate, useSearchParams } from "react-router";
 
-const academicYears = ["vizschool-ay2025", "vizschool-ay2026", "vizschool-ay2027"];
+const academicYears = VIZSCHOOL_ACADEMIC_YEARS;
 
 function CurrentLearnerLayout() {
   const academicYear = useSelectAcademicYear((state) => state.academicYear);

--- a/src/components/layout/vizschool/new-learner-layout.tsx
+++ b/src/components/layout/vizschool/new-learner-layout.tsx
@@ -2,6 +2,7 @@ import { ArrowLeft, CheckCircle2, FilePen, Send } from "lucide-react";
 import { Outlet, useNavigate, useSearchParams } from "react-router";
 
 import { submitVizSchoolEnrollment } from "@/actions/private";
+import { VIZSCHOOL_ACADEMIC_YEARS } from "@/config/academic-years";
 import MaxWidthWrapper from "@/components/max-width-wrapper";
 import NewLearnerSteps from "@/components/private/enrol-student/vizschool/new-learner-steps";
 import VizSchoolSavedDraftsDialog from "@/components/private/vizschool-drafts-list";
@@ -48,7 +49,7 @@ import { useEffect, useRef, useState } from "react";
 import { useMediaQuery } from "react-responsive";
 import { toast } from "sonner";
 
-const academicYears = ["vizschool-ay2025", "vizschool-ay2026", "vizschool-ay2027"];
+const academicYears = VIZSCHOOL_ACADEMIC_YEARS;
 
 function NewLearnerLayout() {
   const studentDrafts = listNewStudentDrafts("viz-school").reverse() || [];

--- a/src/config/academic-years.ts
+++ b/src/config/academic-years.ts
@@ -1,0 +1,42 @@
+/**
+ * Single source of truth for academic years.
+ *
+ * Two deliberately separate lists, because "what a parent may enrol into" and
+ * "what the system still recognizes" are different concerns:
+ *
+ *  - PARENT_FACING_ACADEMIC_YEARS — years parents can enrol into. Drives the
+ *    user-facing selectors (enrolment dropdown, open-house picker, etc.).
+ *  - BACKEND_ACADEMIC_YEARS — every year the system recognizes, including
+ *    historical ones that are no longer open for enrolment. Drives route-guard
+ *    validation and per-year table iteration. Ordered newest-first so backend
+ *    loops scan the most recent year first.
+ *
+ * To open a new academic year: add it to BACKEND_ACADEMIC_YEARS, and to
+ * PARENT_FACING_ACADEMIC_YEARS once it's ready to accept enrolments.
+ */
+
+export type ParentFacingAcademicYear = {
+  /** Internal value / table prefix, e.g. "ay2026". */
+  value: string;
+  /** Short label for compact UI, e.g. "2026". */
+  label: string;
+  /** Display name, e.g. "AY 2026". */
+  name: string;
+  /** The year currently in session (used for "Current Year" badges and fallbacks). */
+  isCurrent: boolean;
+};
+
+export const PARENT_FACING_ACADEMIC_YEARS: ParentFacingAcademicYear[] = [
+  { value: "ay2026", label: "2026", name: "AY 2026", isCurrent: true },
+  { value: "ay2027", label: "2027", name: "AY 2027", isCurrent: false },
+];
+
+/** Every recognized academic year (incl. historical), newest first. */
+export const BACKEND_ACADEMIC_YEARS: string[] = ["ay2027", "ay2026", "ay2025"];
+
+/** VizSchool mirrors the same years behind a `vizschool-` prefix. */
+export const VIZSCHOOL_ACADEMIC_YEARS: string[] = BACKEND_ACADEMIC_YEARS.map((ay) => `vizschool-${ay}`);
+
+/** The academic year currently in session — used as a sensible default/fallback. */
+export const CURRENT_ACADEMIC_YEAR: string =
+  PARENT_FACING_ACADEMIC_YEARS.find((ay) => ay.isCurrent)?.value ?? PARENT_FACING_ACADEMIC_YEARS[0].value;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,4 @@
+import { BACKEND_ACADEMIC_YEARS } from "@/config/academic-years";
 import { classLevels } from "@/data";
 import { EnrolNewStudentFormState, FamilyInfo, Student } from "@/types";
 import { ParentGuardianUploadRequirementsSchema } from "@/zod-schema";
@@ -351,73 +352,44 @@ async function getStatusByEnrolee(academicYear: string, enroleeNumbers: string[]
 
 export async function getStudentsList(parentEmail: string) {
   try {
-    const { data: ay2027studentInformation, error: ay2027studentInformationError } = await supabase
-      .from("ay2027_enrolment_applications")
-      .select("enroleeFullName, birthDay, enroleeNumber, fatherFullName, motherFullName, studentNumber")
-      .or(`fatherEmail.eq.${parentEmail}, motherEmail.eq.${parentEmail}`)
-      .eq("applicationStatus", "Registered");
+    // Query each academic year's table (BACKEND_ACADEMIC_YEARS is newest-first, so a
+    // student's most recent enrolment wins during the dedup below).
+    const perYear = await Promise.all(
+      BACKEND_ACADEMIC_YEARS.map(async (academicYear) => {
+        const { data, error } = await supabase
+          .from(`${academicYear}_enrolment_applications`)
+          .select("enroleeFullName, birthDay, enroleeNumber, fatherFullName, motherFullName, studentNumber")
+          .or(`fatherEmail.eq.${parentEmail}, motherEmail.eq.${parentEmail}`)
+          .eq("applicationStatus", "Registered")
+          .order("enroleeNumber", { ascending: false });
 
-    if (ay2027studentInformationError) {
-      throw new Error(ay2027studentInformationError.message);
-    }
+        if (error) {
+          throw new Error(error.message);
+        }
 
-    const { data: ay2026studentInformation, error: ay2026studentInformationError } = await supabase
-      .from("ay2026_enrolment_applications")
-      .select("enroleeFullName, birthDay, enroleeNumber, fatherFullName, motherFullName, studentNumber")
-      .or(`fatherEmail.eq.${parentEmail}, motherEmail.eq.${parentEmail}`)
-      .eq("applicationStatus", "Registered");
+        const statusByEnrolee = await getStatusByEnrolee(
+          academicYear,
+          data.map((info) => info.enroleeNumber),
+        );
 
-    if (ay2026studentInformationError) {
-      throw new Error(ay2026studentInformationError.message);
-    }
+        return data
+          .map((info) => ({
+            enroleeNumber: info.enroleeNumber,
+            studentName: info.enroleeFullName,
+            age: differenceInYears(new Date(), parseISO(info.birthDay)),
+            mothersName: info.motherFullName ?? "--",
+            fathersName: info.fatherFullName ?? "--",
+            studentNumber: info.studentNumber,
+            // Live SIS lifecycle status; fall back to "Submitted" if no status row exists yet.
+            enrollmentStatus: statusByEnrolee.get(info.enroleeNumber) ?? "Submitted",
+            isVizSchool: (info.studentNumber as string).startsWith("V"),
+          }))
+          // Drop withdrawn/cancelled before dedup so they don't shadow an active prior-AY row.
+          .filter((student) => !HIDDEN_PARENT_STATUSES.includes(student.enrollmentStatus));
+      }),
+    );
 
-    const { data: ay2025studentInformation, error: ay2025studentInformationError } = await supabase
-      .from("ay2025_enrolment_applications")
-      .select("enroleeFullName, birthDay, enroleeNumber, fatherFullName, motherFullName, studentNumber")
-      .or(`fatherEmail.eq.${parentEmail}, motherEmail.eq.${parentEmail}`)
-      .eq("applicationStatus", "Registered")
-      .order("enroleeNumber", { ascending: false });
-
-    if (ay2025studentInformationError) {
-      throw new Error(ay2025studentInformationError.message);
-    }
-
-    const [status2027, status2026, status2025] = await Promise.all([
-      getStatusByEnrolee(
-        "ay2027",
-        ay2027studentInformation.map((info) => info.enroleeNumber),
-      ),
-      getStatusByEnrolee(
-        "ay2026",
-        ay2026studentInformation.map((info) => info.enroleeNumber),
-      ),
-      getStatusByEnrolee(
-        "ay2025",
-        ay2025studentInformation.map((info) => info.enroleeNumber),
-      ),
-    ]);
-
-    const mapStudents = (data: typeof ay2025studentInformation, statusByEnrolee: Map<string, string>) =>
-      data
-        .map((info) => ({
-          enroleeNumber: info.enroleeNumber,
-          studentName: info.enroleeFullName,
-          age: differenceInYears(new Date(), parseISO(info.birthDay)),
-          mothersName: info.motherFullName ?? "--",
-          fathersName: info.fatherFullName ?? "--",
-          studentNumber: info.studentNumber,
-          // Live SIS lifecycle status; fall back to "Submitted" if no status row exists yet.
-          enrollmentStatus: statusByEnrolee.get(info.enroleeNumber) ?? "Submitted",
-          isVizSchool: (info.studentNumber as string).startsWith("V"),
-        }))
-        // Drop withdrawn/cancelled before dedup so they don't shadow an active prior-AY row.
-        .filter((student) => !HIDDEN_PARENT_STATUSES.includes(student.enrollmentStatus));
-
-    const allStudents = [
-      ...mapStudents(ay2027studentInformation, status2027),
-      ...mapStudents(ay2026studentInformation, status2026),
-      ...mapStudents(ay2025studentInformation, status2025),
-    ];
+    const allStudents = perYear.flat();
 
     const studentsList = allStudents.reduce((acc: typeof allStudents, obj) => {
       if (!acc.some((o) => o.studentNumber === obj.studentNumber)) {
@@ -528,7 +500,7 @@ export async function getCurrentAYEnrolledStudents(parentEmail: string) {
 
 export async function getStudentEnrollments(studentNumber: string, parentEmail: string) {
   try {
-    const academicYears = ["ay2027", "ay2026", "ay2025"];
+    const academicYears = BACKEND_ACADEMIC_YEARS;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const allEnrollments: any[] = [];

--- a/src/pages/private/enrol-student/academic-year-selector.tsx
+++ b/src/pages/private/enrol-student/academic-year-selector.tsx
@@ -1,4 +1,5 @@
 import Logo from "@/components/logo";
+import { PARENT_FACING_ACADEMIC_YEARS } from "@/config/academic-years";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -7,10 +8,15 @@ import { cn } from "@/lib/utils";
 import { ArrowUpRight, CircleCheck } from "lucide-react";
 import { memo } from "react";
 
+// Card identity (value/name) is sourced from the academic-year config so the selector
+// can never offer a year the rest of the app doesn't recognize. The marketing copy and
+// logos below stay local to this landing page.
+const [AY_2026, AY_2027] = PARENT_FACING_ACADEMIC_YEARS;
+
 const academicYears = [
   {
-    value: "ay2026",
-    name: "AY 2026",
+    value: AY_2026.value,
+    name: AY_2026.name,
     label: "Academic Year 2026",
     description: "Enrol your child for the ongoing school year.",
 
@@ -25,7 +31,7 @@ const academicYears = [
   },
 
   {
-    value: "vizschool-ay2026",
+    value: `vizschool-${AY_2026.value}`,
     name: "Vizschool AY2026",
     label: "Vizschool AY2026",
     description: "Early registration for AY 2026 starts Jan 2026.",
@@ -35,8 +41,8 @@ const academicYears = [
     logo: VizSchoolLogo,
   },
   {
-    value: "ay2027",
-    name: "AY 2027",
+    value: AY_2027.value,
+    name: AY_2027.name,
     label: "Academic Year 2027",
     description: "Early registration for AY 2027 starts July 2027.",
     details: ["Secure a slot early", "Registration opens 1 July 2026", "Classes begin January 2027"],

--- a/src/pages/private/enrol-student/enrol-student.tsx
+++ b/src/pages/private/enrol-student/enrol-student.tsx
@@ -15,6 +15,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import VizSchoolLogo from "@/components/vizschool-logo";
+import { PARENT_FACING_ACADEMIC_YEARS } from "@/config/academic-years";
 import { ENROL_NEW_STUDENT_TITLE_DESCRIPTION } from "@/data";
 import useSession from "@/hooks/use-session";
 import { canEnrollStudent, cn } from "@/lib/utils";
@@ -178,7 +179,7 @@ function EnrolStudent() {
         <div className="w-full min-h-screen pt-0 md:pt-20 flex items-center justify-center bg-muted">
           {showEnrollmentProcess ? (
             <EnrollmentStepper academicYear={academicYear} setShowEnrollmentProcess={setShowEnrollmentProcess} />
-          ) : academicYear === "vizschool-ay2026" && !schoolFee ? (
+          ) : academicYear.includes("vizschool-") && !schoolFee ? (
             <SchoolFees />
           ) : schoolFee ? (
             <motion.div
@@ -420,17 +421,6 @@ function AcademicYearDropdown() {
   const academicYear = useSelectAcademicYear((state) => state.academicYear);
   const setAcademicYear = useSelectAcademicYear((state) => state.setAcademicYear);
 
-  const academicYears = [
-    {
-      value: "ay2026",
-      label: "2026",
-    },
-    {
-      value: "ay2027",
-      label: "2027",
-    },
-  ];
-
   return (
     <Select value={academicYear} onValueChange={setAcademicYear}>
       <SelectTrigger className="text-primary mt-4 w-max mx-auto text-sm font-bold cursor-pointer">
@@ -438,7 +428,7 @@ function AcademicYearDropdown() {
         <SelectValue placeholder="Choose academic year" />
       </SelectTrigger>
       <SelectContent className="[&_div:focus]:text-primary">
-        {academicYears.map((ay) => (
+        {PARENT_FACING_ACADEMIC_YEARS.map((ay) => (
           <SelectItem key={ay.value} className="text-sm font-bold cursor-pointer" value={ay.value}>
             {ay.label}
           </SelectItem>

--- a/src/pages/private/open-house/open-house-landing.tsx
+++ b/src/pages/private/open-house/open-house-landing.tsx
@@ -1,4 +1,5 @@
 import students from "@/assets/students.webp";
+import { PARENT_FACING_ACADEMIC_YEARS } from "@/config/academic-years";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import SEO, { BASE_URL } from "@/pages/seo";
@@ -131,14 +132,14 @@ export default function OpenHouseLanding() {
                   </label>
 
                   <div className="grid grid-cols-2 gap-3 p-1.5 bg-slate-100 rounded-xl border border-slate-200">
-                    {["ay2026", "ay2027"].map((year) => {
-                      const isSelected = academicYear === year;
+                    {PARENT_FACING_ACADEMIC_YEARS.map((ay) => {
+                      const isSelected = academicYear === ay.value;
 
                       return (
                         <button
-                          key={year}
+                          key={ay.value}
                           type="button"
-                          onClick={() => setAcademicYear(year)}
+                          onClick={() => setAcademicYear(ay.value)}
                           className={cn(
                             "relative cursor-pointer h-14 rounded-lg transition-all duration-300 group overflow-hidden",
                             isSelected
@@ -151,9 +152,9 @@ export default function OpenHouseLanding() {
                                 "text-[10px] uppercase tracking-tighter font-black opacity-60 transition-colors",
                                 isSelected ? "text-primary" : "text-slate-400",
                               )}>
-                              {year === "ay2026" ? "Current Year" : "Upcoming Year"}
+                              {ay.isCurrent ? "Current Year" : "Upcoming Year"}
                             </span>
-                            <span className="text-base font-black tracking-tight">AY {year.replace("ay", "")}</span>
+                            <span className="text-base font-black tracking-tight">AY {ay.label}</span>
                           </div>
 
                           {/* Active Indicator Pin */}

--- a/src/pages/private/student-profile.tsx
+++ b/src/pages/private/student-profile.tsx
@@ -3,6 +3,7 @@
 import PageMetaData from "@/components/page-metadata";
 import Profile from "@/components/private/student-profile/profile";
 import { buttonVariants } from "@/components/ui/button";
+import { CURRENT_ACADEMIC_YEAR } from "@/config/academic-years";
 import { STUDENT_PROFILE_TITLE_DESCRIPTION } from "@/data";
 import { cn } from "@/lib/utils";
 import { ArrowUpRight, FileEdit } from "lucide-react";
@@ -21,7 +22,7 @@ function StudentProfile() {
   }
 
   const ayMatch = params.id.match(/E(\d{2})/);
-  const academicYear = ayMatch ? `ay20${ayMatch[1]}` : "ay2026";
+  const academicYear = ayMatch ? `ay20${ayMatch[1]}` : CURRENT_ACADEMIC_YEAR;
 
   return (
     <>


### PR DESCRIPTION
Replace ~12 scattered hardcoded academic-year lists with one source of truth in src/config/academic-years.ts, exposing two deliberately separate lists:

- PARENT_FACING_ACADEMIC_YEARS — years parents can enrol into; drives the enrolment dropdown, AY selector cards, and open-house picker.
- BACKEND_ACADEMIC_YEARS (+ VIZSCHOOL_ACADEMIC_YEARS) — all recognized years incl. historical; drives the 4 layout route-guards and per-year table iteration in actions/private.ts and lib/utils.ts.

Also collapses getStudentsList's three copy-pasted per-year queries into a single loop over BACKEND_ACADEMIC_YEARS. Adding a future academic year is now a one-line config change.