### PR TITLE
refactor(academic-year,documents): resolve AY from enrolee number; fi…

### DIFF
--- a/src/actions/private.ts
+++ b/src/actions/private.ts
@@ -1,4 +1,4 @@
-import { BACKEND_ACADEMIC_YEARS } from "@/config/academic-years";
+import { academicYearFromEnroleeNumber, BACKEND_ACADEMIC_YEARS } from "@/config/academic-years";
 import { applicationTypes } from "@/data";
 import { supabase } from "@/lib/client";
 import {
@@ -195,10 +195,7 @@ export async function getStudentEnrollmentInformation(enroleeNumber: string) {
 
     if (!session?.user?.email) throw new Error("Not authenticated");
 
-    const match = enroleeNumber.match(/E(\d{2})/);
-    if (!match) throw new Error("Invalid enrolee number format");
-
-    const academicYear = `ay20${match[1]}`;
+    const academicYear = academicYearFromEnroleeNumber(enroleeNumber);
 
     const { data, error: studentEnrollmentInformationError } = await supabase
       .from(`${academicYear}_enrolment_applications`)
@@ -224,10 +221,7 @@ export async function getStudentDetails({ enroleeNumber }: { enroleeNumber: stri
       data: { session },
     } = await supabase.auth.getSession();
 
-    const match = enroleeNumber.match(/E(\d{2})/);
-    if (!match) throw new Error("Invalid enrolee number format");
-
-    const academicYear = `ay20${match[1]}`;
+    const academicYear = academicYearFromEnroleeNumber(enroleeNumber);
 
     const APPLICATIONS_TABLE = `${academicYear}_enrolment_applications`;
     const DOCUMENTS_TABLE = `${academicYear}_enrolment_documents`;
@@ -331,12 +325,6 @@ export async function getStudentDetails({ enroleeNumber }: { enroleeNumber: stri
       fatherPassStatus,
       guardianPassportStatus,
       guardianPassStatus,
-      icaPhoto,
-      icaPhotoStatus,
-      financialSupportDocs,
-      financialSupportDocsStatus,
-      vaccinationInformation,
-      vaccinationInformationStatus,
     } = documents[0];
 
     return {
@@ -350,13 +338,6 @@ export async function getStudentDetails({ enroleeNumber }: { enroleeNumber: stri
         ...siblings,
       },
       studentDocuments: {
-        studentPassApplicationDocuments: applicationTypes.includes(studentInfo.stpApplicationType ?? "")
-          ? [
-              { icaPhoto, icaPhotoStatus },
-              { vaccinationInformation, vaccinationInformationStatus },
-              { financialSupportDocs, financialSupportDocsStatus },
-            ]
-          : null,
         documentsThatExpire: [
           {
             passport,
@@ -467,10 +448,7 @@ export async function getStudentInformation(enroleeNumber: string) {
 
     if (!session?.user?.email) throw new Error("Not authenticated");
 
-    const match = enroleeNumber.match(/E(\d{2})/);
-    if (!match) throw new Error("Invalid enrolee number format");
-
-    const academicYear = `ay20${match[1]}`;
+    const academicYear = academicYearFromEnroleeNumber(enroleeNumber);
 
     const { data: studentInformation, error: studentInformationError } = await supabase
       .from(`${academicYear}_enrolment_applications`)
@@ -525,13 +503,7 @@ export async function getFamilyInformation(enroleeNumber?: string) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let familyInformation: any = null;
 
-    const academicYears = enroleeNumber
-      ? (() => {
-          const match = enroleeNumber.match(/E(\d{2})/);
-          if (!match) throw new Error("Invalid enrolee number format");
-          return [`ay20${match[1]}`];
-        })()
-      : BACKEND_ACADEMIC_YEARS;
+    const academicYears = enroleeNumber ? [academicYearFromEnroleeNumber(enroleeNumber)] : BACKEND_ACADEMIC_YEARS;
 
     for (const academicYear of academicYears) {
       let query = supabase
@@ -605,10 +577,7 @@ export async function getPreviousStudentDocuments(enroleeNumber: string) {
 
     if (!session?.user?.email) throw new Error("Not authenticated");
 
-    const match = enroleeNumber.match(/E(\d{2})/);
-    if (!match) throw new Error("Invalid enrolee number format");
-
-    const academicYear = `ay20${match[1]}`;
+    const academicYear = academicYearFromEnroleeNumber(enroleeNumber);
 
     const { data: studentInformation, error: studentInformationError } = await supabase
       .from(`${academicYear}_enrolment_applications`)
@@ -670,13 +639,7 @@ export async function getPreviousParentGuardianDocuments(enroleeNumber?: string)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let documentsData: any = null;
 
-    const academicYears = enroleeNumber
-      ? (() => {
-          const match = enroleeNumber.match(/E(\d{2})/);
-          if (!match) throw new Error("Invalid enrolee number format");
-          return [`ay20${match[1]}`];
-        })()
-      : BACKEND_ACADEMIC_YEARS;
+    const academicYears = enroleeNumber ? [academicYearFromEnroleeNumber(enroleeNumber)] : BACKEND_ACADEMIC_YEARS;
 
     for (const academicYear of academicYears) {
       let appQuery = supabase
@@ -1482,10 +1445,7 @@ export async function submitExistingEnrollment(
   preCourseDetails: PreCourseDetails,
 ) {
   try {
-    const match = enroleeNumber.match(/E(\d{2})/);
-    if (!match) throw new Error("Invalid enrolee number format");
-
-    const currentAY = `ay20${match[1]}`;
+    const currentAY = academicYearFromEnroleeNumber(enroleeNumber);
 
     const {
       data: { session: existingSession },
@@ -1842,10 +1802,7 @@ export async function getFamilyDocuments(enroleeNumber: string) {
 
     if (!session?.user?.email) throw new Error("Not authenticated");
 
-    const match = enroleeNumber.match(/E(\d{2})/);
-    if (!match) throw new Error("Invalid enrolee number format");
-
-    const academicYear = `ay20${match[1]}`;
+    const academicYear = academicYearFromEnroleeNumber(enroleeNumber);
 
     // Verify ownership via the applications table before querying documents
     const { data: ownership, error: ownershipError } = await supabase

--- a/src/components/private/dashboard/section-cards.tsx
+++ b/src/components/private/dashboard/section-cards.tsx
@@ -1,4 +1,5 @@
 import { getSectionCardsDetails } from "@/actions/private";
+import { tryAcademicYearFromEnroleeNumber } from "@/config/academic-years";
 import { Badge } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -174,8 +175,7 @@ function StatCard({
           <CardContent className="mt-6 px-0 border-t border-slate-200 pt-2">
             <div className="flex flex-col">
               {value.slice(0, 2).map((pendingTask) => {
-                const match = pendingTask.enroleeNumber?.match(/E(\d{2})/);
-                const academicYear = match ? `ay20${match[1]}` : "";
+                const academicYear = tryAcademicYearFromEnroleeNumber(pendingTask.enroleeNumber) ?? "";
 
                 return (
                   <div

--- a/src/components/private/documents/student-files.tsx
+++ b/src/components/private/documents/student-files.tsx
@@ -40,22 +40,6 @@ function StudentFiles({ label, documents }: { label: string; documents: StudentD
   const { session } = useSession();
   const academicYear = searchParams.get("academicYear");
 
-  const studentPassApplicationDocs = documents.studentPassApplicationDocuments
-    ? [
-        { title: "ICA Photo", type: "icaPhoto", data: documents.studentPassApplicationDocuments[0] },
-        {
-          title: "Vaccination Information",
-          type: "vaccinationInformation",
-          data: documents.studentPassApplicationDocuments[1],
-        },
-        {
-          title: "Financial Support Documents",
-          type: "financialSupportDocs",
-          data: documents.studentPassApplicationDocuments[2],
-        },
-      ]
-    : null;
-
   // Grouping documents for cleaner rendering
   const expiringDocs = [
     { title: "Student Pass", type: "pass", data: documents.documentsThatExpire[1] },
@@ -78,19 +62,6 @@ function StudentFiles({ label, documents }: { label: string; documents: StudentD
           This section includes details about the student's documents for this current school year.
         </p>
       </div>
-
-      {studentPassApplicationDocs != null && (
-        <div className="space-y-4">
-          <h2 className="text-xs font-black uppercase tracking-widest text-slate-400 px-1">
-            Student Pass Application Documents
-          </h2>
-          <div className="grid gap-3">
-            {studentPassApplicationDocs.map((doc) => (
-              <DocumentRow key={doc.type} title={doc.title} doc={doc.data} type={doc.type} />
-            ))}
-          </div>
-        </div>
-      )}
 
       {/* Section: Expiring */}
       <div className="space-y-4">

--- a/src/components/private/enrol-student/steps/upload-requirements/student-file-uploader-dialog.tsx
+++ b/src/components/private/enrol-student/steps/upload-requirements/student-file-uploader-dialog.tsx
@@ -69,8 +69,6 @@ const MULTIPLE_FILE_UPLOADS = [
   "pass",
   "birthCert",
   "educCert",
-  "vaccinationInformation",
-  "financialSupportDocs",
 ];
 
 const TO_FOLLOW_DOCS = ["idPicture", "passport", "pass", "birthCert"];
@@ -82,9 +80,6 @@ const NON_EXPIRING_DOCS = [
   "educCert",
   "idPicture",
   "birthCert",
-  "icaPhoto",
-  "vaccinationInformation",
-  "financialSupportDocs",
 ];
 
 const EXPIRING_DOCS = ["pass", "passport"];
@@ -141,7 +136,7 @@ const StudentFileUploaderDialog = memo(function ({
     maxFiles: MULTIPLE_FILE_UPLOADS.includes(name) ? 4 : 1,
     maxSize: 1024 * 1024 * 4, // 4MB max
     accept:
-      name === "idPicture" || (name as string) === "icaPhoto"
+      name === "idPicture"
         ? {
             "image/png": [],
             "image/jpeg": [],
@@ -349,24 +344,6 @@ const StudentFileUploaderDialog = memo(function ({
               <DialogDescription className="font-semibold">
                 Upload a clear and recent document in{" "}
                 <strong> {MULTIPLE_FILE_UPLOADS.includes(name) ? "PDF" : "PNG, JPG, or JPEG"}</strong> format.
-                {(name as string) === "icaPhoto" && (
-                  <span className="mt-2 font-semibold">
-                    {" "}
-                    Recommended digital photo size for online submission is{" "}
-                    <strong className="text-destructive">400 × 514 pixels</strong> in JPEG or similar format that meets
-                    ICA requirements.
-                    <br />
-                    <br /> For ICA‑compliant photos, please follow the official{" "}
-                    <a
-                      href="https://www.ica.gov.sg/photo-guidelines"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-blue-600 underline underline-offset-2">
-                      ICA Photo Guidelines
-                    </a>
-                    .
-                  </span>
-                )}
               </DialogDescription>
             </DialogHeader>
 
@@ -1020,24 +997,6 @@ function StudentFileUploaderDrawer({
             <DrawerDescription className="text-xs font-semibold">
               Upload a clear and recent document in{" "}
               <strong> {MULTIPLE_FILE_UPLOADS.includes(name) ? "PDF" : "PNG, JPG, or JPEG"}</strong> format.
-              {(name as string) === "icaPhoto" && (
-                <span className="mt-2 font-semibold">
-                  {" "}
-                  Recommended digital photo size for online submission is{" "}
-                  <strong className="text-destructive">400 × 514 pixels</strong> in JPEG or similar format that meets
-                  ICA requirements.
-                  <br />
-                  <br /> For ICA‑compliant photos, please follow the official{" "}
-                  <a
-                    href="https://www.ica.gov.sg/photo-guidelines"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-blue-600 underline underline-offset-2">
-                    ICA Photo Guidelines
-                  </a>
-                  .
-                </span>
-              )}
             </DrawerDescription>
           </DrawerHeader>
 

--- a/src/components/private/enrol-student/tabs/upload-requirements/student-file-uploader-dialog.tsx
+++ b/src/components/private/enrol-student/tabs/upload-requirements/student-file-uploader-dialog.tsx
@@ -68,8 +68,6 @@ const MULTIPLE_FILE_UPLOADS = [
   "pass",
   "birthCert",
   "educCert",
-  "vaccinationInformation",
-  "financialSupportDocs",
 ];
 
 const TO_FOLLOW_DOCS = ["idPicture", "passport", "pass", "birthCert"];
@@ -81,9 +79,6 @@ const NON_EXPIRING_DOCS = [
   "educCert",
   "idPicture",
   "birthCert",
-  "icaPhoto",
-  "vaccinationInformation",
-  "financialSupportDocs",
 ];
 
 const EXPIRING_DOCS = ["pass", "passport"];
@@ -140,7 +135,7 @@ const StudentFileUploaderDialog = memo(function ({
     maxFiles: MULTIPLE_FILE_UPLOADS.includes(name) ? 4 : 1,
     maxSize: 1024 * 1024 * 4, // 4MB max
     accept:
-      name === "idPicture" || (name as string) === "icaPhoto"
+      name === "idPicture"
         ? {
             "image/png": [],
             "image/jpeg": [],
@@ -348,24 +343,6 @@ const StudentFileUploaderDialog = memo(function ({
               <DialogDescription className="font-semibold">
                 Upload a clear and recent document in{" "}
                 <strong> {MULTIPLE_FILE_UPLOADS.includes(name) ? "PDF" : "PNG, JPG, or JPEG"}</strong> format.
-                {(name as string) === "icaPhoto" && (
-                  <span className="mt-2 font-semibold">
-                    {" "}
-                    Recommended digital photo size for online submission is{" "}
-                    <strong className="text-destructive">400 × 514 pixels</strong> in JPEG or similar format that meets
-                    ICA requirements.
-                    <br />
-                    <br /> For ICA‑compliant photos, please follow the official{" "}
-                    <a
-                      href="https://www.ica.gov.sg/photo-guidelines"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-blue-600 underline underline-offset-2">
-                      ICA Photo Guidelines
-                    </a>
-                    .
-                  </span>
-                )}
               </DialogDescription>
             </DialogHeader>
 
@@ -1004,24 +981,6 @@ function StudentFileUploaderDrawer({
             <DrawerDescription className="text-xs font-semibold">
               Upload a clear and recent document in{" "}
               <strong> {MULTIPLE_FILE_UPLOADS.includes(name) ? "PDF" : "PNG, JPG, or JPEG"}</strong> format.
-              {(name as string) === "icaPhoto" && (
-                <span className="mt-2 font-semibold">
-                  {" "}
-                  Recommended digital photo size for online submission is{" "}
-                  <strong className="text-destructive">400 × 514 pixels</strong> in JPEG or similar format that meets
-                  ICA requirements.
-                  <br />
-                  <br /> For ICA‑compliant photos, please follow the official{" "}
-                  <a
-                    href="https://www.ica.gov.sg/photo-guidelines"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-blue-600 underline underline-offset-2">
-                    ICA Photo Guidelines
-                  </a>
-                  .
-                </span>
-              )}
             </DrawerDescription>
           </DrawerHeader>
 

--- a/src/components/private/enrol-student/vizschool/steps/upload-requirements/student-file-uploader-dialog.tsx
+++ b/src/components/private/enrol-student/vizschool/steps/upload-requirements/student-file-uploader-dialog.tsx
@@ -68,15 +68,7 @@ const TO_FOLLOW_DOCS = ["idPicture", "passport", "pass", "birthCert"];
 
 const OPTIONAL_DOCS = ["medical", "educCert"];
 
-const NON_EXPIRING_DOCS = [
-  "medical",
-  "educCert",
-  "idPicture",
-  "birthCert",
-  "icaPhoto",
-  "vaccinationInformation",
-  "financialSupportDocs",
-];
+const NON_EXPIRING_DOCS = ["medical", "educCert", "idPicture", "birthCert"];
 
 const EXPIRING_DOCS = ["pass", "passport"];
 
@@ -978,24 +970,6 @@ function StudentFileUploaderDrawer({
             <DrawerDescription className="text-xs font-semibold">
               Upload a clear and recent document in{" "}
               <strong> {MULTIPLE_FILE_UPLOADS.includes(name) ? "PDF" : "PNG, JPG, or JPEG"}</strong> format.
-              {(name as string) === "icaPhoto" && (
-                <span className="mt-2 font-semibold">
-                  {" "}
-                  Recommended digital photo size for online submission is{" "}
-                  <strong className="text-destructive">400 × 514 pixels</strong> in JPEG or similar format that meets
-                  ICA requirements.
-                  <br />
-                  <br /> For ICA‑compliant photos, please follow the official{" "}
-                  <a
-                    href="https://www.ica.gov.sg/photo-guidelines"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-blue-600 underline underline-offset-2">
-                    ICA Photo Guidelines
-                  </a>
-                  .
-                </span>
-              )}
             </DrawerDescription>
           </DrawerHeader>
 

--- a/src/components/private/enrol-student/vizschool/tabs/upload-requirements/student-file-uploader-dialog.tsx
+++ b/src/components/private/enrol-student/vizschool/tabs/upload-requirements/student-file-uploader-dialog.tsx
@@ -68,15 +68,7 @@ const TO_FOLLOW_DOCS = ["idPicture", "passport", "pass", "birthCert"];
 
 const OPTIONAL_DOCS = ["medical", "educCert"];
 
-const NON_EXPIRING_DOCS = [
-  "medical",
-  "educCert",
-  "idPicture",
-  "birthCert",
-  "icaPhoto",
-  "vaccinationInformation",
-  "financialSupportDocs",
-];
+const NON_EXPIRING_DOCS = ["medical", "educCert", "idPicture", "birthCert"];
 
 const EXPIRING_DOCS = ["pass", "passport"];
 
@@ -978,24 +970,6 @@ function StudentFileUploaderDrawer({
             <DrawerDescription className="text-xs font-semibold">
               Upload a clear and recent document in{" "}
               <strong> {MULTIPLE_FILE_UPLOADS.includes(name) ? "PDF" : "PNG, JPG, or JPEG"}</strong> format.
-              {(name as string) === "icaPhoto" && (
-                <span className="mt-2 font-semibold">
-                  {" "}
-                  Recommended digital photo size for online submission is{" "}
-                  <strong className="text-destructive">400 × 514 pixels</strong> in JPEG or similar format that meets
-                  ICA requirements.
-                  <br />
-                  <br /> For ICA‑compliant photos, please follow the official{" "}
-                  <a
-                    href="https://www.ica.gov.sg/photo-guidelines"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-blue-600 underline underline-offset-2">
-                    ICA Photo Guidelines
-                  </a>
-                  .
-                </span>
-              )}
             </DrawerDescription>
           </DrawerHeader>
 

--- a/src/components/private/open-house/steps/upload-requirements/student-file-uploader-dialog.tsx
+++ b/src/components/private/open-house/steps/upload-requirements/student-file-uploader-dialog.tsx
@@ -68,8 +68,6 @@ const MULTIPLE_FILE_UPLOADS = [
   "pass",
   "birthCert",
   "educCert",
-  "vaccinationInformation",
-  "financialSupportDocs",
 ];
 
 const TO_FOLLOW_DOCS = ["idPicture", "passport", "pass", "birthCert"];
@@ -81,9 +79,6 @@ const NON_EXPIRING_DOCS = [
   "educCert",
   "idPicture",
   "birthCert",
-  "icaPhoto",
-  "vaccinationInformation",
-  "financialSupportDocs",
 ];
 
 const EXPIRING_DOCS = ["pass", "passport"];
@@ -140,7 +135,7 @@ const StudentFileUploaderDialog = memo(function ({
     maxFiles: MULTIPLE_FILE_UPLOADS.includes(name) ? 4 : 1,
     maxSize: 1024 * 1024 * 4, // 4MB max
     accept:
-      name === "idPicture" || (name as string) === "icaPhoto"
+      name === "idPicture"
         ? {
             "image/png": [],
             "image/jpeg": [],
@@ -348,24 +343,6 @@ const StudentFileUploaderDialog = memo(function ({
               <DialogDescription className="font-semibold">
                 Upload a clear and recent document in{" "}
                 <strong> {MULTIPLE_FILE_UPLOADS.includes(name) ? "PDF" : "PNG, JPG, or JPEG"}</strong> format.
-                {(name as string) === "icaPhoto" && (
-                  <span className="mt-2 font-semibold">
-                    {" "}
-                    Recommended digital photo size for online submission is{" "}
-                    <strong className="text-destructive">400 × 514 pixels</strong> in JPEG or similar format that meets
-                    ICA requirements.
-                    <br />
-                    <br /> For ICA‑compliant photos, please follow the official{" "}
-                    <a
-                      href="https://www.ica.gov.sg/photo-guidelines"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-blue-600 underline underline-offset-2">
-                      ICA Photo Guidelines
-                    </a>
-                    .
-                  </span>
-                )}
               </DialogDescription>
             </DialogHeader>
 
@@ -1004,24 +981,6 @@ function StudentFileUploaderDrawer({
             <DrawerDescription className="text-xs font-semibold">
               Upload a clear and recent document in{" "}
               <strong> {MULTIPLE_FILE_UPLOADS.includes(name) ? "PDF" : "PNG, JPG, or JPEG"}</strong> format.
-              {(name as string) === "icaPhoto" && (
-                <span className="mt-2 font-semibold">
-                  {" "}
-                  Recommended digital photo size for online submission is{" "}
-                  <strong className="text-destructive">400 × 514 pixels</strong> in JPEG or similar format that meets
-                  ICA requirements.
-                  <br />
-                  <br /> For ICA‑compliant photos, please follow the official{" "}
-                  <a
-                    href="https://www.ica.gov.sg/photo-guidelines"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-blue-600 underline underline-offset-2">
-                    ICA Photo Guidelines
-                  </a>
-                  .
-                </span>
-              )}
             </DrawerDescription>
           </DrawerHeader>
 

--- a/src/components/private/student-profile/student-documents.tsx
+++ b/src/components/private/student-profile/student-documents.tsx
@@ -7,22 +7,6 @@ import { Eye, EyeClosed, FileText } from "lucide-react";
 import { Link } from "react-router";
 
 function StudentDocuments({ label, documents }: { label: string; documents: StudentDocument }) {
-  const studentPassApplicationDocs = documents.studentPassApplicationDocuments
-    ? [
-        { title: "ICA Photo", type: "icaPhoto", data: documents.studentPassApplicationDocuments[0] },
-        {
-          title: "Vaccination Information",
-          type: "vaccinationInformation",
-          data: documents.studentPassApplicationDocuments[1],
-        },
-        {
-          title: "Financial Support Documents",
-          type: "financialSupportDocs",
-          data: documents.studentPassApplicationDocuments[2],
-        },
-      ]
-    : null;
-
   const expiringDocs = [
     { title: "Student Pass", type: "pass", data: documents.documentsThatExpire[1] },
     { title: "Passport", type: "passport", data: documents.documentsThatExpire[0] },
@@ -44,19 +28,6 @@ function StudentDocuments({ label, documents }: { label: string; documents: Stud
           This section includes details about the student's documents for this current school year.
         </p>
       </div>
-
-      {studentPassApplicationDocs != null && (
-        <div className="space-y-4">
-          <h2 className="text-xs font-black uppercase tracking-widest text-slate-400 px-1">
-            Student Pass Application Documents
-          </h2>
-          <div className="grid gap-3">
-            {studentPassApplicationDocs.map((doc) => (
-              <DocumentRow key={doc.type} title={doc.title} doc={doc.data} type={doc.type} />
-            ))}
-          </div>
-        </div>
-      )}
 
       <div className="space-y-4">
         <h2 className="text-xs font-black uppercase tracking-widest text-slate-400 px-1">Documents that expire</h2>

--- a/src/config/academic-years.ts
+++ b/src/config/academic-years.ts
@@ -40,3 +40,27 @@ export const VIZSCHOOL_ACADEMIC_YEARS: string[] = BACKEND_ACADEMIC_YEARS.map((ay
 /** The academic year currently in session — used as a sensible default/fallback. */
 export const CURRENT_ACADEMIC_YEAR: string =
   PARENT_FACING_ACADEMIC_YEARS.find((ay) => ay.isCurrent)?.value ?? PARENT_FACING_ACADEMIC_YEARS[0].value;
+
+/**
+ * Resolve the academic year an enrolee number belongs to, or `null` if it can't
+ * be parsed / matched.
+ *
+ * Enrolee numbers embed the year's last two digits right after the "E"
+ * (e.g. "E26####"), because they're generated as `E${academicYear.slice(-2)}…`.
+ * We match that suffix back against BACKEND_ACADEMIC_YEARS — the true inverse of
+ * generation — instead of assuming the century is "20". That keeps it correct for
+ * any year in the config (e.g. a test "ay9999" resolves from "E99####", not "ay2099").
+ */
+export function tryAcademicYearFromEnroleeNumber(enroleeNumber: string | null | undefined): string | null {
+  if (!enroleeNumber) return null;
+  const match = enroleeNumber.match(/E(\d{2})/);
+  if (!match) return null;
+  return BACKEND_ACADEMIC_YEARS.find((ay) => ay.slice(-2) === match[1]) ?? null;
+}
+
+/** Like {@link tryAcademicYearFromEnroleeNumber}, but throws on an unparseable / unknown enrolee number. */
+export function academicYearFromEnroleeNumber(enroleeNumber: string): string {
+  const academicYear = tryAcademicYearFromEnroleeNumber(enroleeNumber);
+  if (!academicYear) throw new Error(`Invalid or unrecognized enrolee number: "${enroleeNumber}"`);
+  return academicYear;
+}

--- a/src/pages/private/enrol-student/academic-year-selector.tsx
+++ b/src/pages/private/enrol-student/academic-year-selector.tsx
@@ -1,5 +1,4 @@
 import Logo from "@/components/logo";
-import { PARENT_FACING_ACADEMIC_YEARS } from "@/config/academic-years";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -8,15 +7,10 @@ import { cn } from "@/lib/utils";
 import { ArrowUpRight, CircleCheck } from "lucide-react";
 import { memo } from "react";
 
-// Card identity (value/name) is sourced from the academic-year config so the selector
-// can never offer a year the rest of the app doesn't recognize. The marketing copy and
-// logos below stay local to this landing page.
-const [AY_2026, AY_2027] = PARENT_FACING_ACADEMIC_YEARS;
-
 const academicYears = [
   {
-    value: AY_2026.value,
-    name: AY_2026.name,
+    value: "ay2026",
+    name: "AY 2026",
     label: "Academic Year 2026",
     description: "Enrol your child for the ongoing school year.",
 
@@ -31,7 +25,7 @@ const academicYears = [
   },
 
   {
-    value: `vizschool-${AY_2026.value}`,
+    value: "vizschool-ay2026",
     name: "Vizschool AY2026",
     label: "Vizschool AY2026",
     description: "Early registration for AY 2026 starts Jan 2026.",
@@ -41,8 +35,8 @@ const academicYears = [
     logo: VizSchoolLogo,
   },
   {
-    value: AY_2027.value,
-    name: AY_2027.name,
+    value: "ay2027",
+    name: "AY 2027",
     label: "Academic Year 2027",
     description: "Early registration for AY 2027 starts July 2027.",
     details: ["Secure a slot early", "Registration opens 1 July 2026", "Classes begin January 2027"],

--- a/src/pages/private/pending-tasks.tsx
+++ b/src/pages/private/pending-tasks.tsx
@@ -1,4 +1,5 @@
 import { getSectionCardsDetails } from "@/actions/private";
+import { tryAcademicYearFromEnroleeNumber } from "@/config/academic-years";
 import MaxWidthWrapper from "@/components/max-width-wrapper";
 import { buttonVariants } from "@/components/ui/button";
 import useSession from "@/hooks/use-session";
@@ -50,8 +51,7 @@ function PendingTasks() {
         <div className="bg-white rounded-2xl shadow-sm border border-slate-100 overflow-hidden">
           <div className="divide-y divide-slate-100">
             {tasks.map((task) => {
-              const match = task.enroleeNumber.match(/E(\d{2})/);
-              const academicYear = `ay20${match[1]}`;
+              const academicYear = tryAcademicYearFromEnroleeNumber(task.enroleeNumber) ?? "";
 
               return (
                 <div key={task.enroleeNumber} className="p-6 hover:bg-slate-50/50 transition-colors">

--- a/src/pages/private/student-profile.tsx
+++ b/src/pages/private/student-profile.tsx
@@ -3,7 +3,7 @@
 import PageMetaData from "@/components/page-metadata";
 import Profile from "@/components/private/student-profile/profile";
 import { buttonVariants } from "@/components/ui/button";
-import { CURRENT_ACADEMIC_YEAR } from "@/config/academic-years";
+import { CURRENT_ACADEMIC_YEAR, tryAcademicYearFromEnroleeNumber } from "@/config/academic-years";
 import { STUDENT_PROFILE_TITLE_DESCRIPTION } from "@/data";
 import { cn } from "@/lib/utils";
 import { ArrowUpRight, FileEdit } from "lucide-react";
@@ -21,8 +21,7 @@ function StudentProfile() {
     );
   }
 
-  const ayMatch = params.id.match(/E(\d{2})/);
-  const academicYear = ayMatch ? `ay20${ayMatch[1]}` : CURRENT_ACADEMIC_YEAR;
+  const academicYear = tryAcademicYearFromEnroleeNumber(params.id) ?? CURRENT_ACADEMIC_YEAR;
 
   return (
     <>

--- a/src/types.ts
+++ b/src/types.ts
@@ -187,22 +187,6 @@ export type StudentDetails = {
 };
 
 export type StudentDocument = {
-  studentPassApplicationDocuments:
-    | [
-        {
-          icaPhoto: string | null;
-          icaPhotoStatus: string | null;
-        },
-        {
-          vaccinationInformation: string | null;
-          vaccinationInformationStatus: string | null;
-        },
-        {
-          financialSupportDocs: string | null;
-          financialSupportDocsStatus: string | null;
-        },
-      ]
-    | null;
   documentsThatExpire: [
     {
       passport: string | null;


### PR DESCRIPTION
…nish ICA removal

- Add academicYearFromEnroleeNumber / tryAcademicYearFromEnroleeNumber helpers and replace the ~10 scattered `ay20${match}` reconstructions across private.ts, pending-tasks, student-profile, and section-cards.
- Complete removal of the Student Pass (ICA) document group from the StudentDocument type, getStudentDetails, the profile/reupload views, and the dead array/branch references in the 5 uploader dialogs.